### PR TITLE
Cannot Download Binary Files (Incomplete Bytes Issue)

### DIFF
--- a/lib/fl_cloud_storage/vendor/google_drive/google_drive_service.dart
+++ b/lib/fl_cloud_storage/vendor/google_drive/google_drive_service.dart
@@ -242,7 +242,20 @@ class GoogleDriveService implements ICloudService<GoogleDriveFile, GoogleDriveFo
       final mimeTypeParts = contentType.split('/');
       if (mimeTypeParts.isNotEmpty) {
         final prefix = mimeTypeParts.first;
-        return {'application', 'message', 'model', 'text'}.contains(prefix);
+        final subtype = mimeTypeParts.length > 1 ? mimeTypeParts[1] : '';
+        
+        // Exclude binary application types
+        if (prefix == 'application') {
+          final binaryTypes = {
+            'zip', 'gzip', 'tar', 'rar', '7z',
+            'pdf', 'doc', 'docx', 'xls', 'xlsx',
+            'ppt', 'pptx', 'exe', 'bin', 'dmg',
+            'iso', 'img', 'deb', 'rpm'
+          };
+          return !binaryTypes.contains(subtype);
+        }
+        
+        return {'message', 'model', 'text'}.contains(prefix);
       }
       return false;
     }

--- a/lib/fl_cloud_storage/vendor/google_drive/google_drive_service.dart
+++ b/lib/fl_cloud_storage/vendor/google_drive/google_drive_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:async';
 
 import 'package:fl_cloud_storage/fl_cloud_storage.dart';
 import 'package:fl_cloud_storage/fl_cloud_storage/cloud_storage_service.dart';


### PR DESCRIPTION
Currently, downloading binary files does not wait until the entire byte stream is completed. This results in incomplete downloads and corrupted binary files.

Expected Behavior:

The download process should wait until all bytes are fully received before finalizing the file.

Binary files should be downloaded completely and remain intact.

Steps to Reproduce:

Attempt to download a binary file (e.g., .zip, .rar).

Observe that the file size is smaller than expected or cannot be opened properly.

Proposed Fix:

Ensure the download stream is awaited until completion before writing to disk.

Add validation for file size or checksum to confirm successful download.